### PR TITLE
Fix theme

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,7 +8,7 @@
     <div class="{{ .Params.wrapper | default "wrapper" }}">
       
         <div class="page-header {{ .Params.headerstyle | default "page-header-small"}}" filter-color="{{ .Param "tint" | default "orange" }}">
-            <div class="page-header-image" data-parallax="true" style="background-image: url('{{ (.Param "background")  | (default "img/header.jpg" | absURL) }}');">
+            <div class="page-header-image" data-parallax="true" style="background-image: url('{{ or (.Param "background") (default "img/header.jpg" | absURL) }}');">
             </div>
             
             {{ block "title" . }}

--- a/layouts/template/login.html
+++ b/layouts/template/login.html
@@ -5,7 +5,7 @@
     {{ partial "nav" . }}
     <div class="page-header" filter-color="{{.Params.tint}}">
         <div class="page-header-image" 
-             style="background-image: url('{{ (.Param "background")  | (default "img/header.jpg" | absURL) }}');">
+             style="background-image: url('{{ or (.Param "background") (default "img/header.jpg" | absURL) }}');">
         </div>
         <div class="container">
           


### PR DESCRIPTION
The latest [deploy](https://app.netlify.com/sites/hugothemes/deploys/5ed2d2c37e89470006a16c37) of the Hugo Themes broke some themes and looks like this is one of them. 

Please see the relevant [issue](https://github.com/gohugoio/hugoThemes/issues/858#issuecomment-636394599) and the [forum discussion](https://discourse.gohugo.io/t/0-71-1-error-cant-give-argument-to-non-function/25928/2).

I noticed that issue after running into the following error (Hugo `v0.75.1`)

```
ERROR 2020/09/28 11:41:44 render of "page" failed: "..../themes/hugo-now-ui/layouts/_default/baseof.html:11:105": execute of template failed: template: _default/single.html:11:105: executing "_default/single.html" at <"background">: can't give argument to non-function absURL | default "img/header.jpg"
```

These changes fixed the issue on my end. 
